### PR TITLE
Add unit tests for com.dianping.cat.report.task.TaskHelper

### DIFF
--- a/cat-home/pom.xml
+++ b/cat-home/pom.xml
@@ -107,12 +107,24 @@
          <artifactId>java-saml</artifactId>
          <version>2.2.0</version>
       </dependency>
-      
+	
       <dependency>
           <groupId>xmlunit</groupId>
           <artifactId>xmlunit</artifactId>
           <version>1.6</version>
           <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.powermock</groupId>
+         <artifactId>powermock-api-mockito</artifactId>
+         <version>1.6.5</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.powermock</groupId>
+         <artifactId>powermock-module-junit4</artifactId>
+         <version>1.6.5</version>
+         <scope>test</scope>
       </dependency>
    </dependencies>
    <build>

--- a/cat-home/src/test/java/com/dianping/cat/report/task/TaskHelperTest.java
+++ b/cat-home/src/test/java/com/dianping/cat/report/task/TaskHelperTest.java
@@ -22,11 +22,23 @@ import java.util.Calendar;
 import java.util.Date;
 
 import junit.framework.Assert;
+
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
 public class TaskHelperTest {
+
+	@Rule
+	public final ExpectedException thrown = ExpectedException.none();
 
 	@Before
 	public void setUp() throws Exception {
@@ -54,6 +66,11 @@ public class TaskHelperTest {
 	}
 
 	@Test
+	public void testYesterdayZero2() {
+		Assert.assertEquals(new Date(1562626800000L), TaskHelper.yesterdayZero(new Date(1562769422000L)));
+	}
+
+	@Test
 	public void testTodayZero() {
 		Calendar cal = Calendar.getInstance();
 		cal.set(Calendar.DAY_OF_YEAR, 1);
@@ -65,4 +82,82 @@ public class TaskHelperTest {
 		Assert.assertEquals(cal.getTimeInMillis(), todayZero.getTime() + 1L);
 	}
 
+	@PrepareForTest({TaskHelper.class})
+	@Test
+	public void testTodayZero2() throws Exception {
+		Date date = new Date(1562799600000L);
+		PowerMockito.whenNew(Date.class).withAnyArguments().thenReturn(date);
+		Assert.assertEquals(date, TaskHelper.todayZero(null));
+	}
+
+	@Test
+	public void testTodayZero3() {
+		Assert.assertEquals(new Date(1562626800000L), TaskHelper.todayZero(new Date(1562683022000L)));
+	}
+
+	@Test
+	public void testJoinIntArray() {
+		final int[] array = {1, -8, -7, -7, -7, -7, -7, -253968, -7, -24, -24,
+				-2147475464, 4088, -2147483647, 9, 33505273, 1, -8};
+
+		Assert.assertNull(TaskHelper.join((int[]) null, '1', 2, 3));
+
+		Assert.assertEquals("", TaskHelper.join(new int[0], '\u0000', 24, 5));
+		Assert.assertEquals("", TaskHelper.join(new int[0], '\u0000'));
+		Assert.assertEquals("1\u0000-8", TaskHelper.join(array, '\u0000', 16, 17));
+	}
+
+	@Test
+	public void testJoinDoubleArray() {
+		Assert.assertNull(TaskHelper.join((double[]) null, '1', 2, 3));
+
+		Assert.assertEquals("", TaskHelper.join(new double[]{5.1}, '\u0000'));
+		Assert.assertEquals("2.1\u00004.5", TaskHelper.join(new double[]{2.1, 4.5}, '\u0000'));
+		Assert.assertEquals("", TaskHelper.join(new double[]{5.1, 9.2}, '\u0000', 119, 96));
+	}
+
+	@Test
+	public void testJoinNumberArray() {
+		Assert.assertNull(TaskHelper.join((Number[]) null, '1', 2, 3));
+
+		Assert.assertEquals("", TaskHelper.join(new Number[0], '\u0000'));
+		Assert.assertEquals("-100\u0000-891", TaskHelper.join(new Number[]{-100, -891}, '\u0000', 0, 1));
+		Assert.assertEquals("", TaskHelper.join(new Number[0], '\u0000', 139, -1744));
+	}
+
+	@Test
+	public void testJoinThrowsException1() {
+		thrown.expect(ArrayIndexOutOfBoundsException.class);
+		TaskHelper.join(new Number[0], '\u0000', 112, 1071);
+	}
+
+	@Test
+	public void testJoinThrowsException2() {
+		thrown.expect(ArrayIndexOutOfBoundsException.class);
+		TaskHelper.join(new Number[]{-100, -891}, '\u0000', 0, 114);
+	}
+
+	@Test
+	public void testNextMonthStart() {
+		Assert.assertEquals(new Date(1554678000000L), TaskHelper.nextMonthStart(new Date(1552044153000L)));
+	}
+
+	@Test
+	public void testThisHour() {
+		Assert.assertEquals(new Date(1562767200000L), TaskHelper.thisHour(new Date(1562767504000L)));
+	}
+
+	@PrepareForTest({TaskHelper.class})
+	@Test
+	public void testTomorrowZero1() throws Exception {
+		Date date = new Date(1562671353000L);
+		Date date2 = new Date(1562713200000L);
+		PowerMockito.whenNew(Date.class).withAnyArguments().thenReturn(date);
+		Assert.assertEquals(date2, TaskHelper.tomorrowZero(null));
+	}
+
+	@Test
+	public void testTomorrowZero2() {
+		Assert.assertEquals(new Date(1562626800000L), TaskHelper.tomorrowZero(new Date(1562596622000L)));
+	}
 }


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.dianping.cat.report.task.TaskHelper` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.